### PR TITLE
Refactor filter predicates and fix Firebase config

### DIFF
--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -26,7 +26,7 @@ if (typeof window !== "undefined") {
   if (hasAllKeys) {
     appInstance = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
     authInstance = getAuth(appInstance);
-    dbInstance = initializeFirestore(appInstance, { experimentalAutoDetectLongPolling: true, useFetchStreams: false });
+    dbInstance = initializeFirestore(appInstance, { experimentalAutoDetectLongPolling: true });
     storageInstance = getStorage(appInstance);
   } else {
     if (process.env.NODE_ENV !== "production") {


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user encountered a problem and implemented a solution suggested by ChatGPT to address filtering and configuration issues in the coach dashboard.

## Code changes
- **Filter predicates refactoring**: 
  - Renamed `PredicateKey` to `RealFilterKey` for better type clarity
  - Added `num()` helper function to safely handle numeric values with fallback to Infinity
  - Created `aplicarFiltro()` function to centralize filter application logic
  - Updated all filter predicate calls to use the new centralized function
  - Made `filterPredicates` type `Partial<Record<>>` for better type safety

- **Firebase configuration**: 
  - Removed `useFetchStreams: false` parameter from `initializeFirestore` configuration

- **Minor fixes**: 
  - Fixed character encoding issue in dropdown menu label ("Condições")To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/stellar-haven)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-stellar-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>stellar-haven</branchName>-->