### PR TITLE
Fix Vercel deploy error by removing useFetchStreams

### DIFF
--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -26,7 +26,7 @@ if (typeof window !== "undefined") {
   if (hasAllKeys) {
     appInstance = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
     authInstance = getAuth(appInstance);
-    dbInstance = initializeFirestore(appInstance, { experimentalForceLongPolling: true, useFetchStreams: false });
+    dbInstance = initializeFirestore(appInstance, { experimentalForceLongPolling: true });
 
     // Explicitly select the bucket only if it's valid; ignore firebasestorage.app hostnames
     const bucket = (process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "").trim();


### PR DESCRIPTION
## Purpose
Fix a Vercel deployment error by adjusting Firebase Firestore configuration to resolve compatibility issues during the build/deploy process.

## Code changes
- Removed `useFetchStreams: false` parameter from `initializeFirestore` configuration in `lib/firebase.ts`
- Kept `experimentalForceLongPolling: true` to maintain existing polling behavior
- Simplified Firestore initialization to use default fetch stream settingsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/zenith-works)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-zenith-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>zenith-works</branchName>-->