### PR TITLE
Simplify EnablePushButton component to basic notification prompt

### DIFF
--- a/app/components/EnablePushButton.tsx
+++ b/app/components/EnablePushButton.tsx
@@ -1,14 +1,11 @@
 "use client";
 import { useEffect, useState } from "react";
 
-type Perm = "default" | "granted" | "denied";
-
 export default function EnablePushButton() {
   const [ready, setReady] = useState(false);
-  const [perm, setPerm] = useState<Perm>("default");
-  const [optedIn, setOptedIn] = useState<boolean | null>(null);
-  const [busy, setBusy] = useState(false);
-  const [showBlockedHelp, setShowBlockedHelp] = useState(false);
+  const [status, setStatus] = useState<"default" | "enabled" | "blocked">(
+    "default"
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -16,169 +13,43 @@ export default function EnablePushButton() {
     OneSignal.push(async () => {
       setReady(true);
       try {
-        let p: Perm = "default";
-        if (typeof OneSignal.Notifications?.getPermissionStatus === "function") {
-          p = await OneSignal.Notifications.getPermissionStatus();
-        } else if (typeof Notification !== "undefined") {
-          p = Notification.permission as Perm;
-        }
-        setPerm(p);
-      } catch {}
-      try {
-        const inVal =
-          (OneSignal.User?.PushSubscription?.optedIn as boolean | undefined) ??
-          (typeof OneSignal.User?.PushSubscription?.optedIn === "function"
-            ? await OneSignal.User.PushSubscription.optedIn()
-            : undefined);
-        if (typeof inVal === "boolean") setOptedIn(inVal);
-      } catch {
-        setOptedIn(null);
-      }
-
-      try {
-        const dismissed = typeof sessionStorage !== "undefined" && sessionStorage.getItem("attivo_push_blocked_dismissed") === "1";
-        if (!dismissed) {
-          const currentPerm: Perm = typeof OneSignal.Notifications?.getPermissionStatus === "function"
-            ? await OneSignal.Notifications.getPermissionStatus()
-            : (typeof Notification !== "undefined" ? (Notification.permission as Perm) : "default");
-          if (currentPerm === "denied") setShowBlockedHelp(true);
-        }
+        const perm = await OneSignal.Notifications.getPermissionStatus();
+        if (perm === "granted") setStatus("enabled");
+        if (perm === "denied") setStatus("blocked");
       } catch {}
     });
   }, []);
 
-  const refreshState = async () => {
-    try {
-      const OneSignal = (window as any).OneSignal || [];
-      const p: Perm = typeof OneSignal.Notifications?.getPermissionStatus === "function"
-        ? await OneSignal.Notifications.getPermissionStatus()
-        : (typeof Notification !== "undefined" ? (Notification.permission as Perm) : "default");
-      setPerm(p);
-      try {
-        const inVal =
-          (OneSignal.User?.PushSubscription?.optedIn as boolean | undefined) ??
-          (typeof OneSignal.User?.PushSubscription?.optedIn === "function"
-            ? await OneSignal.User.PushSubscription.optedIn()
-            : undefined);
-        if (typeof inVal === "boolean") setOptedIn(inVal);
-      } catch {}
-    } catch {}
-  };
-
-  const toggle = async () => {
-    if (busy) return;
-    setBusy(true);
-    try { if (typeof window !== "undefined" && "vibrate" in navigator) { (navigator as any).vibrate?.(10); } } catch {}
+  const handleEnable = async () => {
     const OneSignal = (window as any).OneSignal || [];
     OneSignal.push(async () => {
       try {
-        if (perm === "denied") {
-          setBusy(false);
-          return;
+        if (OneSignal.Slidedown?.promptPush) {
+          await OneSignal.Slidedown.promptPush();
+        } else if (OneSignal.Notifications?.requestPermission) {
+          await OneSignal.Notifications.requestPermission();
         }
-        if (perm === "default" || optedIn === false) {
-          try {
-            if (OneSignal.Slidedown?.promptPush) {
-              await OneSignal.Slidedown.promptPush();
-            } else if (OneSignal.Notifications?.requestPermission) {
-              await OneSignal.Notifications.requestPermission();
-            }
-          } catch {}
-          try {
-            if (OneSignal.User?.PushSubscription?.optIn) {
-              await OneSignal.User.PushSubscription.optIn();
-            }
-          } catch {}
-        } else {
-          try {
-            if (OneSignal.User?.PushSubscription?.optOut) {
-              await OneSignal.User.PushSubscription.optOut();
-            }
-          } catch {}
-        }
-      } finally {
-        await refreshState();
-        setBusy(false);
-      }
+      } catch {}
+      try {
+        const perm = await OneSignal.Notifications.getPermissionStatus();
+        if (perm === "granted") setStatus("enabled");
+        if (perm === "denied") setStatus("blocked");
+      } catch {}
     });
   };
 
   if (!ready) return null;
-
-  if (perm === "denied") {
-    return (
-      <>
-        <button
-          type="button"
-          onClick={() => setShowBlockedHelp(true)}
-          className="inline-flex items-center rounded-[20px] border-[3px] border-slate-400 bg-white px-3 py-1.5 text-xs text-slate-600 shadow hover:bg-slate-50"
-          title="Notificações bloqueadas no navegador"
-          aria-label="Notificações bloqueadas"
-        >
-          🚫
-        </button>
-
-        {showBlockedHelp && (
-          <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
-            <div
-              className="absolute inset-0 bg-black/40"
-              onClick={() => {
-                try { sessionStorage.setItem("attivo_push_blocked_dismissed", "1"); } catch {}
-                setShowBlockedHelp(false);
-              }}
-            />
-            <div className="relative w-full max-w-sm rounded-2xl bg-white shadow-lg ring-2 ring-rose-400 p-5">
-              <h2 className="text-lg font-semibold text-rose-700">Notificações bloqueadas</h2>
-              <p className="mt-2 text-sm text-slate-700">
-                Para ativar, abre as definições do site no teu navegador e permite as notificações.
-              </p>
-              <ul className="mt-2 text-xs text-slate-600 list-disc pl-5 space-y-1">
-                <li>Clica no cadeado ao lado do endereço.</li>
-                <li>Vai a Permissões &gt; Notificações &gt; Permitir.</li>
-                <li>Recarrega a página e toca no sino para ativar.</li>
-              </ul>
-              <div className="mt-4 flex justify-end">
-                <button
-                  type="button"
-                  onClick={() => {
-                    try { sessionStorage.setItem("attivo_push_blocked_dismissed", "1"); } catch {}
-                    setShowBlockedHelp(false);
-                  }}
-                  className="rounded-[20px] overflow-hidden border-[3px] border-[#706800] text-[#706800] bg-white px-4 py-2 shadow hover:bg-[#FFF4D1]"
-                >
-                  Ok, percebi
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-      </>
-    );
-  }
-
-  const isOn = perm === "granted" && optedIn !== false;
-  const label = isOn ? "Desativar notificações" : "Ativar notificações";
+  if (status === "enabled") return <p>🔔 Notificações ativas!</p>;
+  if (status === "blocked")
+    return <p>🚫 Notificações bloqueadas. Ativa nas definições do site.</p>;
 
   return (
     <button
       type="button"
-      onClick={toggle}
-      disabled={busy}
-      aria-busy={busy}
-      className={`inline-flex items-center gap-1 rounded-[20px] border-[3px] px-3 py-1.5 text-sm shadow transition-colors active:scale-95 ${
-        isOn
-          ? "border-[#706800] text-[#706800] bg-white hover:bg-[#FFF4D1]"
-          : "border-slate-400 text-slate-700 bg-white hover:bg-slate-50"
-      } ${busy ? "opacity-70 cursor-not-allowed" : ""}`}
-      aria-pressed={isOn}
-      aria-label={label}
-      title={label}
+      onClick={handleEnable}
+      className="enable-push-button px-4 py-2.5 rounded-[12px] border border-[#ccc] cursor-pointer bg-white shadow-sm hover:bg-slate-50 text-slate-800"
     >
-      {busy ? (
-        <span className="inline-block h-4 w-4 rounded-full border-2 border-slate-400 border-t-transparent animate-spin" aria-hidden />
-      ) : (
-        <span aria-hidden>{isOn ? "🔔" : "🔕"}</span>
-      )}
+      Ativar notificações 🔔
     </button>
   );
 }


### PR DESCRIPTION
## Purpose

The user requested to ensure the push notification button follows a specific base code pattern that guarantees the button will prompt for notification authorization when clicked and keep notifications active. They wanted a simplified implementation that focuses on the core functionality of requesting notification permissions.

## Code changes

- **Simplified state management**: Removed complex state variables (`optedIn`, `busy`, `showBlockedHelp`) and consolidated to a single `status` state with three values: "default", "enabled", "blocked"
- **Streamlined permission handling**: Replaced complex permission checking logic with straightforward OneSignal API calls
- **Removed modal dialog**: Eliminated the blocked notifications help modal and session storage logic
- **Simplified UI states**: 
  - Default state shows a simple "Ativar notificações 🔔" button
  - Enabled state shows "🔔 Notificações ativas!" message
  - Blocked state shows "🚫 Notificações bloqueadas. Ativa nas definições do site." message
- **Cleaner button handler**: Replaced complex `toggle` function with simple `handleEnable` that always prompts for permissions
- **Updated styling**: Simplified button classes to match the requested base code styling
- **Removed unnecessary features**: Eliminated vibration feedback, loading states, and toggle functionalityTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/vortex-realm)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-vortex-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>vortex-realm</branchName>-->