### PR TITLE
Fix OneSignal notification permission check errors

### DIFF
--- a/app/components/EnablePushButton.tsx
+++ b/app/components/EnablePushButton.tsx
@@ -9,11 +9,12 @@ export default function EnablePushButton() {
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const OneSignal = (window as any).OneSignal || [];
-    OneSignal.push(async () => {
+    const queue = ((window as any).OneSignal = (window as any).OneSignal || []);
+    queue.push(async () => {
       setReady(true);
       try {
-        const perm = await OneSignal.Notifications.getPermissionStatus();
+        const OS = (window as any).OneSignal;
+        const perm = await OS?.Notifications?.getPermissionStatus?.();
         if (perm === "granted") setStatus("enabled");
         if (perm === "denied") setStatus("blocked");
       } catch {}

--- a/app/components/EnablePushButton.tsx
+++ b/app/components/EnablePushButton.tsx
@@ -28,20 +28,22 @@ export default function EnablePushButton() {
   };
 
   const handleBellClick = async () => {
-    const OneSignal = (window as any).OneSignal || [];
-    OneSignal.push(async () => {
+    const queue = ((window as any).OneSignal = (window as any).OneSignal || []);
+    queue.push(async () => {
       try {
+        const OS = (window as any).OneSignal;
         if (status === "default") {
-          if (OneSignal.Slidedown?.promptPush) {
-            await OneSignal.Slidedown.promptPush();
-          } else if (OneSignal.Notifications?.requestPermission) {
-            await OneSignal.Notifications.requestPermission();
+          if (OS?.Slidedown?.promptPush) {
+            await OS.Slidedown.promptPush();
+          } else if (OS?.Notifications?.requestPermission) {
+            await OS.Notifications.requestPermission();
           }
         }
       } catch {}
 
       try {
-        const perm = await OneSignal.Notifications.getPermissionStatus();
+        const OS = (window as any).OneSignal;
+        const perm = await OS?.Notifications?.getPermissionStatus?.();
         const next = perm === "granted" ? "enabled" : perm === "denied" ? "blocked" : "default";
         if (next !== status) {
           setStatus(next);


### PR DESCRIPTION
## Purpose
Fix the error message "não foi possível verificar o estado das notificações" (unable to verify notification status) that appears when clicking the notification button. The user was experiencing issues with the notification permission verification functionality.

## Code changes
- Added optional chaining (`?.`) to OneSignal API calls to prevent errors when methods are undefined
- Improved OneSignal object initialization and queue handling
- Added safer access patterns for `getPermissionStatus()`, `promptPush()`, and `requestPermission()` methods
- Enhanced error handling to gracefully handle cases where OneSignal methods may not be availableTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/swoosh-field)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-swoosh-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>swoosh-field</branchName>-->