### PR TITLE
Link Firebase user to OneSignal notifications

### DIFF
--- a/app/OneSignalInit.tsx
+++ b/app/OneSignalInit.tsx
@@ -1,11 +1,14 @@
 "use client";
 import { useEffect } from "react";
+import { useSession } from "@/lib/auth";
 
 export default function OneSignalInit() {
+  const { uid } = useSession();
+
+  // Load SDK and init once
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    // Carregar o SDK se ainda não estiver presente
     if (!(window as any).OneSignal) {
       const s = document.createElement("script");
       s.src = "https://cdn.onesignal.com/sdks/OneSignalSDK.js";
@@ -17,14 +20,68 @@ export default function OneSignalInit() {
     (window as any).OneSignal.push(function () {
       (window as any).OneSignal.init({
         appId: process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID,
-        allowLocalhostAsSecureOrigin: true, // útil em dev local
-        notifyButton: { enable: false },    // vamos usar o nosso botão
+        allowLocalhostAsSecureOrigin: true,
+        notifyButton: { enable: false },
         serviceWorkerPath: "/OneSignalSDKWorker.js",
         serviceWorkerUpdaterPath: "/OneSignalSDKUpdaterWorker.js",
         serviceWorkerParam: { scope: "/" },
       });
     });
   }, []);
+
+  // Link/unlink the current Firebase user to OneSignal device
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const queue = ((window as any).OneSignal = (window as any).OneSignal || []);
+    queue.push(async () => {
+      try {
+        const OS = (window as any).OneSignal;
+        if (uid) {
+          if (typeof OS?.login === "function") {
+            await OS.login(uid);
+          } else if (typeof OS?.setExternalUserId === "function") {
+            await OS.setExternalUserId(uid);
+          }
+          if (OS?.User?.addTag) {
+            await OS.User.addTag("uid", uid);
+          } else if (typeof OS?.sendTag === "function") {
+            await OS.sendTag("uid", uid);
+          }
+        } else {
+          if (typeof OS?.logout === "function") {
+            await OS.logout();
+          } else if (typeof OS?.removeExternalUserId === "function") {
+            await OS.removeExternalUserId();
+          }
+          if (OS?.User?.removeTag) {
+            await OS.User.removeTag("uid");
+          }
+        }
+      } catch {}
+    });
+  }, [uid]);
+
+  // On permission/subscription changes, ensure the user is linked
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const queue = ((window as any).OneSignal = (window as any).OneSignal || []);
+    queue.push(() => {
+      const OS = (window as any).OneSignal;
+      try {
+        const relink = async () => {
+          try {
+            if (!uid) return;
+            if (typeof OS?.login === "function") await OS.login(uid);
+            else if (typeof OS?.setExternalUserId === "function") await OS.setExternalUserId(uid);
+            if (OS?.User?.addTag) await OS.User.addTag("uid", uid);
+            else if (typeof OS?.sendTag === "function") await OS.sendTag("uid", uid);
+          } catch {}
+        };
+        OS?.Notifications?.addEventListener?.("permissionChange", relink);
+        OS?.Notifications?.addEventListener?.("subscribe", relink);
+      } catch {}
+    });
+  }, [uid]);
 
   return null;
 }


### PR DESCRIPTION
## Purpose

The user needed to fix OneSignal notifications to properly receive the user information when notifications are activated. The current implementation was working but wasn't linking the authenticated user to OneSignal, which is essential for targeted notifications.

## Code changes

- **Added user session integration**: Import and use `useSession` hook to get the current user's `uid`
- **User linking on authentication**: Added effect to link/unlink Firebase user ID to OneSignal device using `login()`/`logout()` or fallback to `setExternalUserId()`
- **User tagging**: Set "uid" tag on OneSignal device for additional user identification
- **Event listeners**: Added listeners for permission and subscription changes to ensure user remains linked
- **Error handling**: Wrapped OneSignal API calls in try-catch blocks for robustness
- **Code cleanup**: Removed Portuguese comments and improved code organizationTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 30`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/glow-studio)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-glow-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>glow-studio</branchName>-->