### PR TITLE
Add debug logging and fallback for OneSignal app ID

### DIFF
--- a/app/OneSignalInit.tsx
+++ b/app/OneSignalInit.tsx
@@ -16,10 +16,13 @@ export default function OneSignalInit() {
       document.head.appendChild(s);
     }
 
+    const envAppId = process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID;
+    console.log("ENV appId =", envAppId);
+
     (window as any).OneSignal = (window as any).OneSignal || [];
     (window as any).OneSignal.push(function () {
       (window as any).OneSignal.init({
-        appId: process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID,
+        appId: envAppId || "9fa86255-e2fe-4c8f-9efc-6a2aa9bd3b51",
         allowLocalhostAsSecureOrigin: true,
         notifyButton: { enable: false },
         serviceWorkerPath: "/OneSignalSDKWorker.js",


### PR DESCRIPTION
## Purpose

Fix OneSignal initialization issues where the app ID was not being properly loaded from environment variables. The user was experiencing "This app ID does not match any existing app" errors because `process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID` was returning `undefined` at runtime, causing OneSignal to initialize without a valid app ID.

## Code changes

- **Added debug logging**: Console log to display the environment variable value during initialization to help diagnose build-time environment variable injection issues
- **Added fallback app ID**: Implemented a fallback mechanism that uses the hardcoded app ID (`9fa86255-e2fe-4c8f-9efc-6a2aa9bd3b51`) when the environment variable is undefined
- **Extracted environment variable**: Moved the environment variable access to a separate variable for better debugging and cleaner code

These changes ensure OneSignal always initializes with a valid app ID while providing visibility into environment variable loading issues during deployment.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 34`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/echo-home)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-echo-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>echo-home</branchName>-->