### PR TITLE
Add WhatsApp integration and phone number support

### DIFF
--- a/app/coach/client/[uid]/page.tsx
+++ b/app/coach/client/[uid]/page.tsx
@@ -116,6 +116,7 @@ export default function CoachClientProfilePage() {
   const [lastCheckinYMD, setLastCheckinYMD] = useState<string | null>(null);
   const [nextCheckinYMD, setNextCheckinYMD] = useState<string | null>(null);
   const [nextDue, setNextDue] = useState<boolean>(false);
+  const [phone, setPhone] = useState<string | null>(null);
 
   // Hydration target
   const [metaAgua, setMetaAgua] = useState<number | null>(null);
@@ -224,6 +225,7 @@ export default function CoachClientProfilePage() {
       const uSnap = await getDoc(doc(db, "users", uid));
       const u = (uSnap.data() as any) || {};
       setEmail(u.email ?? "—");
+      try { const p = (u.phone ?? u.phoneNumber ?? u.telefone ?? "").toString().trim(); setPhone(p || null); } catch { setPhone(null); }
       setActive(typeof u.active === "boolean" ? u.active : true);
       setPlEnabled(!!u.powerlifting);
       setImgConsent(!!u.imageUseConsent);
@@ -676,6 +678,17 @@ export default function CoachClientProfilePage() {
               <Badge variant={imgConsent ? "secondary" : "destructive"}>
                 Consent. fotos: {imgConsent ? "Sim" : "Não"}{imgConsentAt ? ` • ${ymd(imgConsentAt)}` : ""}
               </Badge>
+              {nextDue && phone && (
+                <a
+                  href={`https://wa.me/${(phone || '').replace(/[^\d]/g, '')}?text=${encodeURIComponent(`Olá ${name.split(' ')[0] || ''}! Está na hora do teu check-in. Consegues marcar a avaliação?`)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm bg-emerald-600 hover:bg-emerald-700 text-white"
+                  title="Enviar WhatsApp"
+                >
+                  <span>WhatsApp</span>
+                </a>
+              )}
             </div>
           </div>
           <div className="flex flex-col items-stretch gap-2 w-full sm:w-auto sm:items-end">
@@ -1338,7 +1351,7 @@ export default function CoachClientProfilePage() {
 
                   {c.commentPublic && (
                     <div className="mt-2 text-sm">
-                      <span className="font-medium">Comentário público: </span>{c.commentPublic}
+                      <span className="font-medium">Comentário p��blico: </span>{c.commentPublic}
                     </div>
                   )}
 

--- a/app/coach/page.tsx
+++ b/app/coach/page.tsx
@@ -60,6 +60,7 @@ type Cliente = {
   id: string;
   nome: string;
   email?: string;
+  phone?: string;
   active?: boolean;
   ultimoDF?: DailyFeedback | null;
   metaAguaLitros: number;
@@ -262,6 +263,7 @@ function CoachDashboard() {
     contaInativa: false,
   });
 
+  const cleanPhone = (p?: string) => (p ? String(p).replace(/[^\d]/g, "") : "");
   async function fetchClientes() {
     setLoading(true);
     try {
@@ -291,6 +293,7 @@ function CoachDashboard() {
               const nd: Date | null = data.nextCheckinDate?.toDate?.() ?? null;
               if (nd) nextCheckinYMD = lisbonYMD(nd);
               else if (typeof data.nextCheckinText === "string") nextCheckinYMD = data.nextCheckinText;
+              (u as any).phone = (data.phone ?? data.phoneNumber ?? data.telefone ?? "").toString().trim() || undefined;
             }
           } catch {}
           if (!nextCheckinYMD) {
@@ -359,6 +362,7 @@ function CoachDashboard() {
             id: u.id,
             nome: nomeFinal,
             email: u.email,
+            phone: (u as any).phone,
             active: u.active,
             ultimoDF: m.last ?? null,
             metaAguaLitros: metaAgua,
@@ -587,6 +591,19 @@ function CoachDashboard() {
                     {typeof c.ultimoDF?.alimentacao100 === "boolean" && ` • Alimentação OK: ${c.ultimoDF?.alimentacao100 ? "Sim" : "Não"}`}
                     {(typeof c.ultimoDF?.peso === "number" || typeof c.ultimoDF?.weight === "number") &&
                       ` • Peso: ${(c.ultimoDF?.peso ?? c.ultimoDF?.weight)}kg`}
+                  </div>
+                )}
+
+                {(c.dueStatus && c.phone) && (
+                  <div className="pt-1">
+                    <button
+                      type="button"
+                      onClick={(e) => { e.preventDefault(); e.stopPropagation(); const url = `https://wa.me/${cleanPhone(c.phone)}?text=${encodeURIComponent(`Olá ${c.nome.split(' ')[0] || ''}! Está na hora do teu check-in. Consegues marcar a avaliação? Próximo CI: ${c.nextCheckinYMD ?? '—'}.`)}`; window.open(url, "_blank", "noopener,noreferrer"); }}
+                      className="inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-sm bg-emerald-600 hover:bg-emerald-700 text-white"
+                      title="Enviar WhatsApp"
+                    >
+                      <span>WhatsApp</span>
+                    </button>
                   </div>
                 )}
               </CardContent>

--- a/app/components/EnablePushButton.tsx
+++ b/app/components/EnablePushButton.tsx
@@ -220,7 +220,7 @@ export default function EnablePushButton() {
         className="enable-push-button relative h-10 w-10 rounded-full border border-[#ccc] cursor-pointer bg-white shadow-sm hover:bg-slate-50 flex items-center justify-center"
       >
         <Bell className="h-5 w-5 text-slate-700" />
-        {status === "blocked" && (
+        {status !== "enabled" && (
           <span
             aria-hidden
             className="pointer-events-none absolute left-1 right-1 top-1/2 -translate-y-1/2 block h-[2px] bg-rose-600 rotate-45 rounded"

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -280,12 +280,6 @@ export default function DashboardPage() {
   if (loading) return <div className="p-4">A carregar…</div>;
   if (!uid) return <div className="p-4">Inicia sessão para ver o teu painel.</div>;
 
-  // Próximo check-in: estados
-
-  useEffect(() => {
-    if (isPastCheckin || isTodayCheckin) setShowCheckinModal(true);
-  }, [isPastCheckin, isTodayCheckin]);
-
   // WhatsApp (mensagem para marcar avaliação quando já passou ou é hoje)
   const waOverdueHref = `https://wa.me/${COACH_WHATSAPP}?text=${encodeURIComponent(
     `Olá Coach! Quero marcar a avaliação. O meu check-in está para ${nextCheckin ?? "—"}.`

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -81,6 +81,7 @@ export default function DashboardPage() {
   const [lastCheckin, setLastCheckin] = useState<string | null>(null);
   const [nextCheckin, setNextCheckin] = useState<string | null>(null);
   const [objetivoPeso, setObjetivoPeso] = useState<"ganho" | "perda" | null>(null);
+  const [showCheckinModal, setShowCheckinModal] = useState(false);
 
   // Nome e metas
   const [displayName, setDisplayName] = useState<string>("O meu painel");
@@ -275,6 +276,10 @@ export default function DashboardPage() {
   // Próximo check-in: estados
   const isPastCheckin = !!nextCheckin && nextCheckin < lisbonTodayYMD();
   const isTodayCheckin = !!nextCheckin && nextCheckin === lisbonTodayYMD();
+
+  useEffect(() => {
+    if (isPastCheckin || isTodayCheckin) setShowCheckinModal(true);
+  }, [isPastCheckin, isTodayCheckin]);
 
   // WhatsApp (mensagem para marcar avaliação quando já passou ou é hoje)
   const waOverdueHref = `https://wa.me/${COACH_WHATSAPP}?text=${encodeURIComponent(

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -467,6 +467,38 @@ export default function DashboardPage() {
           Terminar sessão
         </button>
       </div>
+
+      {showCheckinModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/50" onClick={() => setShowCheckinModal(false)} />
+          <div className="relative w-full max-w-md rounded-2xl bg-white shadow-2xl ring-1 ring-slate-300">
+            <div className="flex items-center justify-between border-b px-4 py-3">
+              <h2 className="text-lg font-semibold">Marcar avaliação</h2>
+              <button type="button" aria-label="Fechar" className="rounded-md px-2 py-1 text-slate-600 hover:bg-slate-100" onClick={() => setShowCheckinModal(false)}>✕</button>
+            </div>
+            <div className="p-4 space-y-3 text-slate-800">
+              <p>Está na altura do teu check-in{nextCheckin ? ` (${nextCheckin})` : ""}. Marca a tua avaliação.</p>
+              <div className="flex gap-2 justify-end pt-1">
+                <a
+                  href={waOverdueHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="px-4 py-2 rounded-xl bg-[#D4AF37] text-white shadow hover:bg-[#BE9B2F]"
+                >
+                  WhatsApp
+                </a>
+                <button
+                  type="button"
+                  onClick={() => setShowCheckinModal(false)}
+                  className="rounded-xl border border-slate-400 bg-white px-4 py-2 shadow-sm hover:bg-slate-50"
+                >
+                  Fechar
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -106,6 +106,13 @@ export default function DashboardPage() {
   // Meta de água (única fonte = users/{uid}.metaAgua)
   const [latestMetaAgua, setLatestMetaAgua] = useState<number | null>(null);
 
+  const isPastCheckin = !!nextCheckin && nextCheckin < lisbonTodayYMD();
+  const isTodayCheckin = !!nextCheckin && nextCheckin === lisbonTodayYMD();
+
+  useEffect(() => {
+    if (isPastCheckin || isTodayCheckin) setShowCheckinModal(true);
+  }, [isPastCheckin, isTodayCheckin]);
+
   const todayId = useMemo(() => ymdUTC(new Date()), []);
   const isoStart = useMemo(() => startOfISOWeekUTC(new Date()), []);
   const isoEnd = useMemo(() => endOfISOWeekUTC(new Date()), []);
@@ -274,8 +281,6 @@ export default function DashboardPage() {
   if (!uid) return <div className="p-4">Inicia sessão para ver o teu painel.</div>;
 
   // Próximo check-in: estados
-  const isPastCheckin = !!nextCheckin && nextCheckin < lisbonTodayYMD();
-  const isTodayCheckin = !!nextCheckin && nextCheckin === lisbonTodayYMD();
 
   useEffect(() => {
     if (isPastCheckin || isTodayCheckin) setShowCheckinModal(true);

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -12,6 +12,7 @@ export default function RegisterPage() {
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -48,6 +49,7 @@ export default function RegisterPage() {
       await setDoc(userRef, {
         name: name.trim(),
         email: email.trim().toLowerCase(),
+        phone: (phone || "").toString().trim() || null,
         role: "client",
         onboardingDone: false,
         active: true,
@@ -108,6 +110,14 @@ export default function RegisterPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               required
+            />
+            <input
+              className="border border-slate-400 bg-white shadow-sm rounded px-3 py-2"
+              type="tel"
+              placeholder="Telemóvel (ex.: 351912345678)"
+              value={phone}
+              onChange={(e) => setPhone(e.target.value)}
+              inputMode="tel"
             />
             <input
               className="border border-slate-400 bg-white shadow-sm rounded px-3 py-2"


### PR DESCRIPTION
## Purpose

Based on user requirements to enhance the coaching platform with better communication features:
- Add phone number collection during user registration
- Enable WhatsApp messaging for coaches to contact clients when check-ins are due
- Improve notification bell design to show inactive state with red strike-through
- Add check-in reminder popup for clients in the dashboard

## Code changes

**Registration & User Data:**
- Added phone number field to registration form (`app/register/page.tsx`)
- Store phone numbers in user documents with fallback field names support

**Coach Features:**
- Added WhatsApp buttons in coach dashboard and client profile pages when check-ins are due
- Phone number retrieval and cleaning functionality for WhatsApp links
- Pre-filled WhatsApp messages with client names and check-in reminders

**Client Dashboard:**
- Added modal popup that appears when check-ins are overdue or due today
- Modal includes WhatsApp button to contact coach for scheduling

**Notification Bell:**
- Updated design to show red strike-through line when notifications are not enabled
- Changed condition from `status === "blocked"` to `status !== "enabled"`

**Data Handling:**
- Added phone number state management across coach and client views
- Implemented phone number cleaning utility for WhatsApp URL formattingTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 35`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/mystic-forge)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-mystic-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>mystic-forge</branchName>-->