### PR TITLE
Add client dashboard notifications for coach plan updates

### DIFF
--- a/app/coach/client/[uid]/page.tsx
+++ b/app/coach/client/[uid]/page.tsx
@@ -619,6 +619,20 @@ export default function CoachClientProfilePage() {
       if (kind === "training") { payload.trainingUrl = url; payload.trainingUpdatedAt = serverTimestamp(); }
       else { payload.dietUrl = url; payload.dietUpdatedAt = serverTimestamp(); }
       await setDoc(doc(db, "users", uid, "plans", "latest"), payload, { merge: true });
+      try {
+        const title = "Planos atualizados";
+        const message = kind === "training" ? "Novo plano de treino disponível" : "Nova sugestão alimentar disponível";
+        await addDoc(collection(db, "users", uid, "coachNotifications"), {
+          kind: "planos_atualizados",
+          type: kind,
+          title,
+          message,
+          createdAt: serverTimestamp(),
+          read: false,
+        });
+      } catch (e) {
+        console.warn("Falha ao registar notificação de planos:", e);
+      }
       if (kind === "training") { setTrainingUrl(url); setTrainingAt(new Date()); } else { setDietUrl(url); setDietAt(new Date()); }
     } catch (e: any) {
       const msg = e?.message || "Falha no upload.";

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -101,6 +101,9 @@ export default function DashboardPage() {
   const [aguaMedia7, setAguaMedia7] = useState<number | null>(null);
   const [passosMedia7, setPassosMedia7] = useState<number | null>(null);
 
+  // Aviso de planos atualizados pelo coach
+  const [planNotice, setPlanNotice] = useState<{ id: string; title: string; message: string } | null>(null);
+
   // Pesos médios semanais
   const [pesoMedioSemanaAtual, setPesoMedioSemanaAtual] = useState<number | null>(null);
   const [pesoMedioSemanaAnterior, setPesoMedioSemanaAnterior] = useState<number | null>(null);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -362,8 +362,20 @@ export default function DashboardPage() {
         <div className="w-10" />
       </div>
 
-      {(needsDaily || needsWeekly) && (
+      {(planNotice || needsDaily || needsWeekly) && (
         <div className="grid grid-cols-1 gap-3">
+          {planNotice && (
+            <div className="rounded-2xl bg-[#FFF4D1] shadow-lg ring-2 ring-[#706800] p-5 flex flex-wrap gap-3 items-center justify-between text-[#706800]">
+              <div className="min-w-0">
+                <div className="text-sm">{planNotice.title}</div>
+                <div className="text-lg truncate">✅ {planNotice.message}</div>
+              </div>
+              <div className="flex gap-2">
+                <Link href="/plans" className="px-4 py-2 rounded-xl bg-[#D4AF37] text-white shadow hover:bg-[#BE9B2F]">Ver planos</Link>
+                <button type="button" onClick={dismissPlanNotice} className="rounded-xl border border-[#706800] bg-white px-4 py-2 shadow-sm hover:bg-[#FFF4D1]">Fechar</button>
+              </div>
+            </div>
+          )}
           {needsDaily && (
             <div className="rounded-2xl bg-[#FFF4D1] shadow-lg ring-2 ring-[#706800] p-5 flex flex-wrap gap-3 items-center justify-between text-[#706800]">
               <div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -280,6 +280,34 @@ export default function DashboardPage() {
         if (!toYMD(udata.lastCheckinDate)) setLastCheckin(toYMD(c0.date));
         if (!toYMD(udata.nextCheckinDate)) setNextCheckin(toYMD(c0.nextDate));
       }
+
+      // Notificação de planos atualizados (não lida)
+      try {
+        let q = query(
+          collection(db, `users/${uid}/coachNotifications`),
+          where("read", "==", false),
+          where("kind", "==", "planos_atualizados"),
+          orderBy("createdAt", "desc"),
+          limit(1)
+        );
+        let qs = await getDocs(q);
+        if (qs.empty) {
+          try {
+            q = query(collection(db, `users/${uid}/coachNotifications`), where("read", "==", false), orderBy("createdAt", "desc"), limit(5));
+            qs = await getDocs(q);
+          } catch {}
+        }
+        const doc0 = qs.docs.find((d) => (d.get("kind") === "planos_atualizados")) || null;
+        if (doc0) {
+          const title = String(doc0.get("title") || "Planos atualizados");
+          const message = String(doc0.get("message") || "Recebeste novos planos (treino/alimentação).");
+          setPlanNotice({ id: doc0.id, title, message });
+        } else {
+          setPlanNotice(null);
+        }
+      } catch {
+        setPlanNotice(null);
+      }
     })().catch((e) => console.error("Dashboard load error:", e));
   }, [uid, todayId, isoStart, isoEnd]);
 

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -19,6 +19,9 @@ import {
   orderBy,
   limit,
   query,
+  where,
+  updateDoc,
+  serverTimestamp,
 } from "firebase/firestore";
 
 /** ===== Helpers de datas (Portugal/Lisboa) ===== */

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -314,6 +314,14 @@ export default function DashboardPage() {
   if (loading) return <div className="p-4">A carregar…</div>;
   if (!uid) return <div className="p-4">Inicia sessão para ver o teu painel.</div>;
 
+  async function dismissPlanNotice() {
+    try {
+      if (!uid || !planNotice) return;
+      await updateDoc(doc(db, `users/${uid}/coachNotifications/${planNotice.id}`), { read: true, readAt: serverTimestamp() });
+    } catch {}
+    setPlanNotice(null);
+  }
+
   // WhatsApp (mensagem para marcar avaliação quando já passou ou é hoje)
   const waOverdueHref = `https://wa.me/${COACH_WHATSAPP}?text=${encodeURIComponent(
     `Olá Coach! Quero marcar a avaliação. O meu check-in está para ${nextCheckin ?? "—"}.`


### PR DESCRIPTION
## Purpose

The user requested to add a notification system to the client dashboard that alerts clients whenever their coach uploads new files (training plans or nutrition plans). This ensures clients are immediately aware when they receive new plans from their coach.

## Code changes

- **Coach client page**: Added notification creation when uploading training or diet plans
  - Creates `coachNotifications` documents with plan update details
  - Includes notification type, title, message, and timestamp
  - Handles both training and diet plan uploads with appropriate messages

- **Client dashboard**: Added plan notification display and management
  - Queries for unread plan update notifications on dashboard load
  - Displays notification banner with plan update message
  - Provides "Ver planos" (View plans) button to navigate to plans page
  - Includes dismiss functionality to mark notifications as read
  - Uses yellow/gold styling to match existing notification designTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 37`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/zenith-haven)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-zenith-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>zenith-haven</branchName>-->