### PR TITLE
Make OneSignal API origin configurable via env var

### DIFF
--- a/app/api/notify/route.ts
+++ b/app/api/notify/route.ts
@@ -6,6 +6,7 @@ export async function POST(req: Request) {
 
     const APP_ID = process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID;
     const REST = process.env.ONESIGNAL_REST_API_KEY;
+    const ORIGIN = process.env.ONESIGNAL_API_ORIGIN || "https://api.onesignal.com";
 
     if (!APP_ID || !REST) {
       return NextResponse.json({ error: "Missing OneSignal keys" }, { status: 500 });
@@ -34,7 +35,7 @@ export async function POST(req: Request) {
         include_aliases: { external_id: [uid] }
       };
 
-      let res = await fetch("https://api.onesignal.com/notifications", {
+      let res = await fetch(`${ORIGIN}/notifications`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json; charset=utf-8",
@@ -49,7 +50,7 @@ export async function POST(req: Request) {
           ...base,
           filters: [{ field: "tag", key: "uid", relation: "=", value: uid }],
         };
-        const res2 = await fetch("https://api.onesignal.com/notifications", {
+        const res2 = await fetch(`${ORIGIN}/notifications`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json; charset=utf-8",
@@ -77,7 +78,7 @@ export async function POST(req: Request) {
       // Enviar para todos os subscritos
       const payload = { ...base, included_segments: ["Subscribed Users"] };
 
-      const res = await fetch("https://api.onesignal.com/notifications", {
+      const res = await fetch(`${ORIGIN}/notifications`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json; charset=utf-8",

--- a/functions/index.js
+++ b/functions/index.js
@@ -8,6 +8,7 @@ const db = admin.firestore();
 async function sendPush({ uid, title, message, url, coaches = false }) {
   const appId = process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID;
   const key = process.env.ONESIGNAL_REST_API_KEY;
+  const origin = process.env.ONESIGNAL_API_ORIGIN || "https://api.onesignal.com";
   if (!appId || !key) return;
   const payload = {
     app_id: appId,
@@ -22,7 +23,7 @@ async function sendPush({ uid, title, message, url, coaches = false }) {
   } else {
     payload.included_segments = ["Subscribed Users"]; // fallback
   }
-  await fetch("https://api.onesignal.com/notifications", {
+  await fetch(`${origin}/notifications`, {
     method: "POST",
     headers: { "Content-Type": "application/json; charset=utf-8", Authorization: `Basic ${key}` },
     body: JSON.stringify(payload),


### PR DESCRIPTION
## Purpose
Based on the conversation indicating this is for a European region, this change allows configuring the OneSignal API endpoint to support different regional API origins while maintaining backward compatibility with the default US endpoint.

## Code changes
- Added `ONESIGNAL_API_ORIGIN` environment variable with fallback to default `https://api.onesignal.com`
- Replaced hardcoded OneSignal API URLs with configurable `ORIGIN`/`origin` variable in:
  - `app/api/notify/route.ts` (3 fetch calls)
  - `functions/index.js` (1 fetch call)
- Maintains backward compatibility by defaulting to existing API endpoint when env var is not setTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 40`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/flare-home)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-flare-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>flare-home</branchName>-->