### PR TITLE
Fix Firebase Storage bucket configuration to use appspot.com

### DIFF
--- a/app/api/storage/inbody/route.ts
+++ b/app/api/storage/inbody/route.ts
@@ -43,7 +43,8 @@ function initAdmin() {
 }
 
 function mapBucketName(name?: string) {
-  const n = (name || "").trim().replace(/^gs:\/\//, "");
+  let n = (name || "").trim().replace(/^gs:\/\//, "");
+  if (n.endsWith(".firebasestorage.app")) n = n.replace(/\.firebasestorage\.app$/, ".appspot.com");
   return n;
 }
 

--- a/app/api/storage/photos/route.ts
+++ b/app/api/storage/photos/route.ts
@@ -44,7 +44,8 @@ function initAdmin() {
 }
 
 function mapBucketName(name?: string) {
-  const n = (name || "").trim().replace(/^gs:\/\//, "");
+  let n = (name || "").trim().replace(/^gs:\/\//, "");
+  if (n.endsWith(".firebasestorage.app")) n = n.replace(/\.firebasestorage\.app$/, ".appspot.com");
   return n;
 }
 

--- a/app/api/storage/plans/route.ts
+++ b/app/api/storage/plans/route.ts
@@ -15,7 +15,8 @@ function initAdmin() {
   if (admin.apps.length) return admin.app();
   const raw = (process.env.FIREBASE_SERVICE_ACCOUNT || "").trim();
   const rawBucket = (process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "").trim();
-  const bucketName = rawBucket.replace(/^gs:\/\//, "");
+  let bucketName = rawBucket.replace(/^gs:\/\//, "");
+  if (bucketName.endsWith(".firebasestorage.app")) bucketName = bucketName.replace(/\.firebasestorage\.app$/, ".appspot.com");
   let credObj: any = null;
   if (raw) {
     let text = raw;
@@ -58,8 +59,13 @@ export async function POST(req: NextRequest) {
   try {
     const app = initAdmin();
     const auth = app.auth();
-    const envPrimary = (process.env.FIREBASE_UPLOAD_BUCKET || process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "").trim().replace(/^gs:\/\//, "");
-    const envAlt = (process.env.FIREBASE_ALT_BUCKET || "").trim().replace(/^gs:\/\//, "");
+    const norm = (v?: string) => {
+      let n = (v || "").trim().replace(/^gs:\/\//, "");
+      if (n.endsWith(".firebasestorage.app")) n = n.replace(/\.firebasestorage\.app$/, ".appspot.com");
+      return n;
+    };
+    const envPrimary = norm(process.env.FIREBASE_UPLOAD_BUCKET || process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET);
+    const envAlt = norm(process.env.FIREBASE_ALT_BUCKET);
     const candidates = [envPrimary, envAlt].filter(Boolean);
     if (candidates.length === 0) return NextResponse.json({ error: 'no_bucket_configured' }, { status: 500 });
 

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -34,12 +34,13 @@ if (typeof window !== "undefined") {
     } catch {}
     dbInstance = initializeFirestore(appInstance, { experimentalForceLongPolling: true });
 
-    // Explicitly select the bucket only if it's valid; ignore firebasestorage.app hostnames
-    const bucket = (process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "").trim();
+    // Explicitly select the bucket only if it's the canonical appspot.com domain
+    const rawBucket = (process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET || "").trim();
     let gsUrl: string | undefined = undefined;
-    if (bucket) {
-      const isValid = bucket.startsWith("gs://") || bucket.endsWith(".appspot.com");
-      if (isValid) gsUrl = bucket.startsWith("gs://") ? bucket : `gs://${bucket}`;
+    if (rawBucket) {
+      const name = rawBucket.replace(/^gs:\/\//, "");
+      const isAppspot = name.endsWith(".appspot.com");
+      if (isAppspot) gsUrl = `gs://${name}`;
     }
     try {
       storageInstance = gsUrl ? getStorage(appInstance, gsUrl) : getStorage(appInstance);


### PR DESCRIPTION
## Purpose

The user requested to correct Firebase Storage configuration to use the canonical `mais-ativo-ofc.appspot.com` domain instead of `firebasestorage.app` across all code that utilizes bucket functionality, both on client and server side.

## Code changes

- **Updated bucket name mapping logic**: Added automatic conversion from `.firebasestorage.app` to `.appspot.com` domains in multiple API routes (`inbody`, `photos`, `plans`)
- **Standardized bucket normalization**: Created a reusable `norm()` function in the plans route to handle bucket name transformations consistently
- **Modified client-side Firebase initialization**: Updated `lib/firebase.ts` to only accept canonical `.appspot.com` domains and ignore `.firebasestorage.app` hostnames
- **Enhanced bucket validation**: Improved bucket name validation logic to ensure only valid appspot.com domains are used for storage initialization

The changes ensure consistent use of the canonical Firebase Storage bucket domain across the entire application.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 48`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d835c63ccff2422ca990ae8dfe67c42b/quantum-studio)

👀 [Preview Link](https://d835c63ccff2422ca990ae8dfe67c42b-quantum-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d835c63ccff2422ca990ae8dfe67c42b</projectId>-->
<!--<branchName>quantum-studio</branchName>-->